### PR TITLE
Fix npmjs.org publishing

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,3 +38,5 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Publishing dry-run
+        run: npm publish --access public --dry-run

--- a/doc/changes/changes_0.5.1.md
+++ b/doc/changes/changes_0.5.1.md
@@ -17,6 +17,6 @@ This release upgrades dependencies on top of 0.5.0.
 * Updated `eslint:^9.20.0` to `^9.39.2`
 * Updated `@jest/globals:^29.7.0` to `^30.2.0`
 * Updated `ts-jest:^29.2.5` to `^29.4.6`
-* Updated `typescript-eslint:^8.23.0` to `^8.49.0`
+* Updated `typescript-eslint:^8.23.0` to `^8.50.0`
 * Updated `typescript:5.7.3` to `5.9.3`
 * Updated `jest:^29.7.0` to `^30.2.0`

--- a/doc/changes/changes_0.5.1.md
+++ b/doc/changes/changes_0.5.1.md
@@ -1,4 +1,4 @@
-# Extension Manager Interface 0.5.1, released 2025-12-17
+# Extension Manager Interface 0.5.1, released 2025-12-18
 
 Code name: Upgrade Dependencies on top of 0.5.0
 

--- a/doc/developer_guide/developer_guide.md
+++ b/doc/developer_guide/developer_guide.md
@@ -22,3 +22,5 @@ npm run lint
 ## Releasing
 
 Use [release-droid](https://github.com/exasol/release-droid) for creating releases and publishing to [NPM Registry](https://www.npmjs.com/package/@exasol/extension-manager-interface).
+
+The release build [release.yml](../../.github/workflows/release.yml) for publishing to npmjs.org will be triggered when the GitHub release is published.

--- a/doc/developer_guide/developer_guide.md
+++ b/doc/developer_guide/developer_guide.md
@@ -29,4 +29,4 @@ npx npm-check-updates -u && npm i
 
 Use [release-droid](https://github.com/exasol/release-droid) for creating releases and publishing to [NPM Registry](https://www.npmjs.com/package/@exasol/extension-manager-interface).
 
-The release build [release.yml](../../.github/workflows/release.yml) for publishing to npmjs.org will be triggered when the GitHub release is published.
+The release build [`release.yml`](../../.github/workflows/release.yml) for publishing to `npmjs.org` will be triggered when the GitHub release is published.

--- a/doc/developer_guide/developer_guide.md
+++ b/doc/developer_guide/developer_guide.md
@@ -19,6 +19,12 @@ npm run test-watch
 npm run lint
 ```
 
+## Upgrade Dependencies
+
+```sh
+npx npm-check-updates -u && npm i
+```
+
 ## Releasing
 
 Use [release-droid](https://github.com/exasol/release-droid) for creating releases and publishing to [NPM Registry](https://www.npmjs.com/package/@exasol/extension-manager-interface).

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "ts-jest": "^29.4.6",
                 "ts-node": "^10.9.2",
                 "typescript": "5.9.3",
-                "typescript-eslint": "^8.49.0"
+                "typescript-eslint": "^8.50.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1521,17 +1521,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
-            "integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz",
+            "integrity": "sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.49.0",
-                "@typescript-eslint/type-utils": "8.49.0",
-                "@typescript-eslint/utils": "8.49.0",
-                "@typescript-eslint/visitor-keys": "8.49.0",
+                "@typescript-eslint/scope-manager": "8.50.0",
+                "@typescript-eslint/type-utils": "8.50.0",
+                "@typescript-eslint/utils": "8.50.0",
+                "@typescript-eslint/visitor-keys": "8.50.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.1.0"
@@ -1544,7 +1544,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.49.0",
+                "@typescript-eslint/parser": "^8.50.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
@@ -1560,17 +1560,17 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
-            "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz",
+            "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.49.0",
-                "@typescript-eslint/types": "8.49.0",
-                "@typescript-eslint/typescript-estree": "8.49.0",
-                "@typescript-eslint/visitor-keys": "8.49.0",
+                "@typescript-eslint/scope-manager": "8.50.0",
+                "@typescript-eslint/types": "8.50.0",
+                "@typescript-eslint/typescript-estree": "8.50.0",
+                "@typescript-eslint/visitor-keys": "8.50.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1586,14 +1586,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
-            "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz",
+            "integrity": "sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.49.0",
-                "@typescript-eslint/types": "^8.49.0",
+                "@typescript-eslint/tsconfig-utils": "^8.50.0",
+                "@typescript-eslint/types": "^8.50.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1608,14 +1608,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
-            "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz",
+            "integrity": "sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.49.0",
-                "@typescript-eslint/visitor-keys": "8.49.0"
+                "@typescript-eslint/types": "8.50.0",
+                "@typescript-eslint/visitor-keys": "8.50.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1626,9 +1626,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
-            "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz",
+            "integrity": "sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1643,15 +1643,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
-            "integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz",
+            "integrity": "sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.49.0",
-                "@typescript-eslint/typescript-estree": "8.49.0",
-                "@typescript-eslint/utils": "8.49.0",
+                "@typescript-eslint/types": "8.50.0",
+                "@typescript-eslint/typescript-estree": "8.50.0",
+                "@typescript-eslint/utils": "8.50.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -1668,9 +1668,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
-            "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz",
+            "integrity": "sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1682,16 +1682,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
-            "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz",
+            "integrity": "sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.49.0",
-                "@typescript-eslint/tsconfig-utils": "8.49.0",
-                "@typescript-eslint/types": "8.49.0",
-                "@typescript-eslint/visitor-keys": "8.49.0",
+                "@typescript-eslint/project-service": "8.50.0",
+                "@typescript-eslint/tsconfig-utils": "8.50.0",
+                "@typescript-eslint/types": "8.50.0",
+                "@typescript-eslint/visitor-keys": "8.50.0",
                 "debug": "^4.3.4",
                 "minimatch": "^9.0.4",
                 "semver": "^7.6.0",
@@ -1749,16 +1749,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.49.0.tgz",
-            "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz",
+            "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.49.0",
-                "@typescript-eslint/types": "8.49.0",
-                "@typescript-eslint/typescript-estree": "8.49.0"
+                "@typescript-eslint/scope-manager": "8.50.0",
+                "@typescript-eslint/types": "8.50.0",
+                "@typescript-eslint/typescript-estree": "8.50.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1773,13 +1773,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
-            "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz",
+            "integrity": "sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/types": "8.50.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -5520,16 +5520,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.49.0.tgz",
-            "integrity": "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==",
+            "version": "8.50.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.50.0.tgz",
+            "integrity": "sha512-Q1/6yNUmCpH94fbgMUMg2/BSAr/6U7GBk61kZTv1/asghQOWOjTlp9K8mixS5NcJmm2creY+UFfGeW/+OcA64A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.49.0",
-                "@typescript-eslint/parser": "8.49.0",
-                "@typescript-eslint/typescript-estree": "8.49.0",
-                "@typescript-eslint/utils": "8.49.0"
+                "@typescript-eslint/eslint-plugin": "8.50.0",
+                "@typescript-eslint/parser": "8.50.0",
+                "@typescript-eslint/typescript-estree": "8.50.0",
+                "@typescript-eslint/utils": "8.50.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "devDependencies": {
         "@jest/globals": "^30.2.0",
         "eslint": "^9.39.2",
-        "typescript-eslint": "^8.49.0",
+        "typescript-eslint": "^8.50.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "module",
     "description": "Interface for extensions for the Exasol extension manager.",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/exasol/extension-manager-interface"
+    },
     "scripts": {
         "build": "npm run generate && tsc --build",
         "generate": "node generate-version.mjs",


### PR DESCRIPTION
Publishing failed:

https://github.com/exasol/extension-manager-interface/actions/runs/20304488760/job/58318109042

```
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=768616116
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@exasol%2fextension-manager-interface - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/exasol/extension-manager-interface" from provenance
```